### PR TITLE
(re)add support for SGrid

### DIFF
--- a/dune/xt/grid/gridprovider/cube.hh
+++ b/dune/xt/grid/gridprovider/cube.hh
@@ -79,6 +79,12 @@ class CubeGridProviderFactory
     static const int id = 1;
   };
 
+  template <int dim, int dimw, class ctype>
+  struct ElementVariant<Dune::SGrid<dim, dimw, ctype>>
+  {
+    static const int id = 1;
+  };
+
 #if HAVE_DUNE_SPGRID
   template <class ct, int dim, template <int> class Refinement, class Comm>
   struct ElementVariant<Dune::SPGrid<ct, dim, Refinement, Comm>>

--- a/dune/xt/grid/grids.hh
+++ b/dune/xt/grid/grids.hh
@@ -19,6 +19,7 @@
 # include <dune/grid/alugrid.hh>
 #endif
 #include <dune/grid/yaspgrid.hh>
+#include <dune/grid/sgrid.hh>
 
 #if HAVE_DUNE_ALUGRID
 # include <dune/alugrid/grid.hh>

--- a/dune/xt/grid/type_traits.hh
+++ b/dune/xt/grid/type_traits.hh
@@ -51,6 +51,12 @@ struct is_grid<Dune::YaspGrid<dim, Coordinates>> : public std::true_type
 {
 };
 
+template <int dim, int dimw, class ctype>
+struct is_grid<Dune::SGrid<dim, dimw, ctype>> : public std::true_type
+{
+};
+
+
 #if HAVE_ALBERTA
 
 template <int dim, int dimworld>


### PR DESCRIPTION
In a quick test I tried to create a `YaspGrid`, which of course failed b.c. some coordinate stuff. So as long as dune-grid still supports `SGrid`, I would like to do so, too... (Btw.: not tested against dune-grid master, if/once `SGrid` is completely removed, this needs to be reverted).