### PR TITLE
[WIP] Manual iteration removal

### DIFF
--- a/dune/xt/grid/dd/glued.hh
+++ b/dune/xt/grid/dd/glued.hh
@@ -299,8 +299,7 @@ public:
     const size_t global_index_of_local_entity = local_to_global_indices_->operator[](subd)[local_entity_index];
     const auto global_micro_grid_view = global_grid_view();
     const auto entity_it_end = global_micro_grid_view.template end<0>();
-    for (auto entity_it = global_micro_grid_view.template begin<0>(); entity_it != entity_it_end; ++entity_it) {
-      const auto& entity = *entity_it;
+    for (auto&& entity : elements(global_micro_grid_view)) {
       if (global_micro_grid_view.indexSet().index(entity) == global_index_of_local_entity)
         return entity;
     }
@@ -331,9 +330,7 @@ public:
     const auto subd = subdomain_and_local_entity_index.first;
     const auto local_index_of_global_entity = subdomain_and_local_entity_index.second;
     const auto local_grid_view = extract_local_view<layer>()(*local_grids_[subd], max_local_level(subd));
-    const auto entity_it_end = local_grid_view.template end<0>();
-    for (auto entity_it = local_grid_view.template begin<0>(); entity_it != entity_it_end; ++entity_it) {
-      const auto& entity = *entity_it;
+    for (auto&& entity : elements(local_grid_view)) {
       if (local_grid_view.indexSet().index(entity) == local_index_of_global_entity)
         return entity;
     }
@@ -546,9 +543,7 @@ public:
       // create the container, therefore
       const auto local_leaf_view = local_grids_[macro_entity_index]->leaf_view();
       // * walk the local grid (manually, to have access to the entity pointer)
-      const auto local_entity_it_end = local_leaf_view.template end<0>();
-      for (auto local_entity_it = local_leaf_view.template begin<0>(); local_entity_it != local_entity_it_end;
-           ++local_entity_it) {
+      for (auto&& entity : elements(local_leaf_view)) {
         const auto& local_entity = *local_entity_it;
         //        logger.debug() << "local_entity: " << local_leaf_view.indexSet().index(local_entity) << " ";
         if (local_entity.hasBoundaryIntersections()) {

--- a/dune/xt/grid/gridprovider/cube.hh
+++ b/dune/xt/grid/gridprovider/cube.hh
@@ -334,11 +334,9 @@ public:
     // global grid part
     const auto global_grid_part = factory.globalGridView();
     // walk the grid
-    const auto entity_it_end = global_grid_part->template end<0, All_Partition>();
-    for (auto entity_it = global_grid_part->template begin<0, All_Partition>(); entity_it != entity_it_end;
-         ++entity_it) {
+
+    for (auto&& entity : elements(*global_grid_part, Partitions::all)) {
       // get center of entity
-      const auto& entity = *entity_it;
       const auto center = entity.geometry().center();
       // decide on the subdomain this entity shall belong to
       std::vector<size_t> whichPartition(GridType::dimension, 0);


### PR DESCRIPTION
One would think this is a trivial change, but since gridparts and gridview differ in their default Partion type for iterators, it actually isn't. Basically every ```elements(X)``` call where ```X``` can be both would need to explicitly add ```Partitions::all``` to be equivalent, afaict. Not sure we want that.