### PR TITLE
[python] python formatter, fix imports

### DIFF
--- a/python/dune/xt/CMakeLists.txt
+++ b/python/dune/xt/CMakeLists.txt
@@ -10,4 +10,3 @@
 # ~~~
 
 add_subdirectory(grid)
-

--- a/python/dune/xt/grid/CMakeLists.txt
+++ b/python/dune/xt/grid/CMakeLists.txt
@@ -13,4 +13,3 @@ dune_pybindxi_add_module(_boundaryinfo EXCLUDE_FROM_ALL boundaryinfo.cc)
 dune_pybindxi_add_module(_types EXCLUDE_FROM_ALL types.cc)
 dune_pybindxi_add_module(_walker EXCLUDE_FROM_ALL walker.cc)
 dune_pybindxi_add_module(_provider EXCLUDE_FROM_ALL provider.cc)
-

--- a/python/dune/xt/grid/__init__.py
+++ b/python/dune/xt/grid/__init__.py
@@ -13,11 +13,11 @@
 from dune.xt import guarded_import
 
 for mod_name in (
-    '_boundaryinfo',
-    '_types',
-    '_walker',
-    '_provider',
-    ):
+        '_boundaryinfo',
+        '_types',
+        '_walker',
+        '_provider',
+):
     guarded_import(globals(), 'dune.xt.grid', mod_name)
 
 
@@ -33,4 +33,3 @@ def make_walker(gridprovider, level=0):
 def make_apply_on_dirichlet_intersections(boundaryinfo, grid, layer='leaf_view', *args, **kwargs):
     factory = globals()['make_apply_on_dirichlet_intersections_{}_{}'.format(layer, grid.grid_type)]
     return factory(boundaryinfo, *args, **kwargs)
-

--- a/python/dune/xt/grid/boundaryinfo.cc
+++ b/python/dune/xt/grid/boundaryinfo.cc
@@ -18,12 +18,14 @@
 
 #include <dune/pybindxi/pybind11.h>
 #include <dune/pybindxi/stl.h>
+
 #include <dune/xt/common/tuple.hh>
+
+#include <dune/xt/grid/grids.hh>
 
 #include <python/dune/xt/common/exceptions.bindings.hh>
 #include <python/dune/xt/common/bindings.hh>
 #include <python/dune/xt/grid/boundaryinfo.bindings.hh>
-#include <python/dune/xt/grid/available_types.hh>
 
 
 using namespace Dune::XT::Common;
@@ -72,7 +74,7 @@ void bind_grid_layer(pybind11::module& m, std::integral_constant<size_t, counter
 }
 
 
-template <class GridTuple = Dune::XT::Grid::bindings::AvailableTypes>
+template <class GridTuple = Dune::XT::Grid::AvailableGridTypes>
 void bind_grid(pybind11::module& m)
 {
   using Grid = typename GridTuple::head_type;

--- a/python/dune/xt/grid/boundaryinfo.py
+++ b/python/dune/xt/grid/boundaryinfo.py
@@ -10,7 +10,7 @@
 # ~~~
 
 try:
-    from dune.xt._boundaryinfo import *
+    from dune.xt.grid._boundaryinfo import *
 except ImportError as e:
     import os
     import logging

--- a/python/dune/xt/grid/provider.cc
+++ b/python/dune/xt/grid/provider.cc
@@ -24,10 +24,9 @@
 #include <python/dune/xt/common/bindings.hh>
 #include <python/dune/xt/grid/grids.bindings.hh>
 #include <python/dune/xt/grid/gridprovider.hh>
-#include <python/dune/xt/grid/available_types.hh>
 
 
-template <class Tuple = Dune::XT::Grid::bindings::AvailableTypes>
+template <class Tuple = Dune::XT::Grid::AvailableGridTypes>
 void addbind_for_Grid(pybind11::module& m)
 {
   using namespace Dune::XT::Grid;

--- a/python/dune/xt/grid/provider.py
+++ b/python/dune/xt/grid/provider.py
@@ -10,7 +10,7 @@
 # ~~~
 
 try:
-    from dune.xt._provider import *
+    from dune.xt.grid._provider import *
 except ImportError as e:
     import os
     import logging

--- a/python/dune/xt/grid/types.cc
+++ b/python/dune/xt/grid/types.cc
@@ -19,12 +19,13 @@
 #include <dune/pybindxi/pybind11.h>
 #include <dune/pybindxi/stl.h>
 
+#include <dune/xt/grid/grids.hh>
+
 #include <python/dune/xt/common/bindings.hh>
-#include <python/dune/xt/grid/available_types.hh>
 #include <python/dune/xt/grid/grids.bindings.hh>
 
 
-template <class Tuple = Dune::XT::Grid::bindings::AvailableTypes>
+template <class Tuple = Dune::XT::Grid::AvailableGridTypes>
 void addbind_for_Grid(pybind11::module& m, std::vector<std::string>& available_types)
 {
   using G = typename Tuple::head_type;

--- a/python/dune/xt/grid/types.py
+++ b/python/dune/xt/grid/types.py
@@ -11,7 +11,7 @@
 # ~~~
 
 try:
-    from dune.xt._types import *
+    from dune.xt.grid._types import *
 except ImportError as e:
     import os
     import logging

--- a/python/dune/xt/grid/walker.cc
+++ b/python/dune/xt/grid/walker.cc
@@ -28,8 +28,6 @@
 #include <python/dune/xt/grid/walker.bindings.hh>
 #include <python/dune/xt/grid/walker/apply-on.bindings.hh>
 
-#include <python/dune/xt/grid/available_types.hh>
-
 template <class G, Dune::XT::Grid::Layers layer, Dune::XT::Grid::Backends backend>
 void bind_walker(pybind11::module& m)
 {
@@ -40,7 +38,7 @@ void bind_walker(pybind11::module& m)
 } // ... bind_walker(...)
 
 
-template <class Tuple = Dune::XT::Grid::bindings::AvailableTypes>
+template <class Tuple = Dune::XT::Grid::AvailableGridTypes>
 void addbind_for_Grid(pybind11::module& m)
 {
   using namespace Dune::XT::Grid;


### PR DESCRIPTION
This is mostly applying the python formatter and fixing deprecation warnings. However, I am not sure about the changed imports like
```diff
-    from dune.xt._boundaryinfo import *
+    from dune.xt.grid._boundaryinfo import *
```
Could one of you have a quick look, @renefritze, @ftalbrecht?